### PR TITLE
fix: 🐛 프롬프트를 prompt-toolkit 기반으로 변경, option+화살표로 이동 시 커서가 튀지 않게 처리

### DIFF
--- a/snippy/utils/io_utils.py
+++ b/snippy/utils/io_utils.py
@@ -1,14 +1,16 @@
 import asyncio
-import readline
+
+from prompt_toolkit import prompt
+from prompt_toolkit.styles import Style
 
 
 def run_async(func, *args, **kwargs):
     return asyncio.run(func(*args, **kwargs))
 
+promptStyle = Style.from_dict({
+    'prompt': 'ansiblue bold',  # 프롬프트 텍스트 스타일
+    'input': 'ansiwhite bold',  # 입력 텍스트 스타일
+})
 
-def get_input(prompt: str) -> str:
-    readline.set_startup_hook(lambda: readline.insert_text(""))
-    try:
-        return input(prompt).strip()
-    finally:
-        readline.set_startup_hook(None)
+def get_input(prompt_message: str) -> str:
+    return prompt(prompt_message, style=promptStyle).strip()


### PR DESCRIPTION
[커밋 메시지에 공백 포함 시, 단어 간 이동으로 커서를 맨 앞으로 옮기려 하면 오른쪽 바깥 영역으로 튀어나감 #1](https://github.com/narashin/snippy/issues/1) 문제를 해결합니다.